### PR TITLE
Merger: Extract sub-tiles from upper zoom levels

### DIFF
--- a/merger/src/lib/log.ts
+++ b/merger/src/lib/log.ts
@@ -5,7 +5,7 @@ function nowString(): string {
     return `[${getFormattedDate(new Date(), 'D/M/Y, h:m:s')}]`;
 }
 
-enum LogSeverity {
+export enum LogSeverity {
     ERROR,
     WARN,
     INFO,
@@ -13,9 +13,13 @@ enum LogSeverity {
 }
 
 class Logger {
-    constructor(private readonly loggerName: string) {}
+    constructor(
+        private readonly loggerName: string,
+        private readonly severity: LogSeverity = LogSeverity.DEBUG
+    ) {}
 
     public log(message: string, severity: LogSeverity): void {
+        if (severity > this.severity) return;
         const levelName = LogSeverity[severity];
 
         const logInfoStr = `${nowString()} [${levelName}] ${this.loggerName}: `;

--- a/merger/src/server.ts
+++ b/merger/src/server.ts
@@ -15,6 +15,20 @@ type SourceName = 'dcsnsw' | 'strava' | 'bom';
 
 class NotFoundError extends BaseError {}
 
+function getParent(x: string, y: string, zoom: string) {
+    const halfX = parseInt(x, 10) / 2;
+    const halfY = parseInt(y, 10) / 2;
+    return {
+        z: (parseInt(zoom, 10) - 1).toString(),
+        x: Math.floor(halfX).toString(),
+        y: Math.floor(halfY).toString(),
+        xOffset: halfX % 1,
+        yOffset: halfY % 1,
+        xSize: 1 - (halfX % 1),
+        ySize: 1 - (halfY % 1),
+    };
+}
+
 function createBlank() {
     return sharp({
         create: {
@@ -39,8 +53,9 @@ async function getSource(
     x: string,
     y: string,
     zoom: string
-): Promise<Buffer> {
+): Promise<[Buffer, string]> {
     try {
+        logger.info(zoom);
         const request = await axios({
             method: 'get',
             url: `https://osm.timporritt.com/source/${name}/${sw}/${zoom}/${x}/${y}`,
@@ -49,14 +64,48 @@ async function getSource(
                 'User-Agent': 'NodeJS',
             },
         });
-        return request.data;
+        return [request.data, zoom];
     } catch (e) {
+        if (zoom != '0') {
+            const parentTile = getParent(x, y, zoom);
+            logger.info(`Parent tile is ${parentTile.z},${parentTile.x},${parentTile.y}`);
+            const p = await getSource(name, sw, parentTile.x, parentTile.y, parentTile.z);
+            logger.warn(`Missing ${zoom},${x},${y} - got ${p[1]}`);
+            return p;
+        }
         logger.error(
             `${name}: (${sw}, ${zoom}, ${x}, ${y}) - ${e?.response?.status}: ${e?.response?.statusText}`
         );
         throw new NotFoundError(e);
         // return createBlank();
     }
+}
+
+function getPartOfParent(desiredZoom: string, actualZoom: string, x: string, y: string) {
+    const diff = parseInt(desiredZoom) - parseInt(actualZoom);
+    logger.info(`d: ${diff}`);
+    let z = desiredZoom;
+    let n = 0;
+    let partialX = 0;
+    let partialY = 0;
+    let size = 1;
+    let newX = x;
+    let newY = y;
+    while (z != actualZoom) {
+        const parent = getParent(newX, newY, z);
+        logger.info(
+            `n: ${n}, ${newX}, ${newY}, ${z}, ${parent.xOffset}, ${parent.xOffset}, ${parent.xSize}`
+        );
+        partialX += parent.xOffset * Math.pow(0.5, diff - (n + 1));
+        partialY += parent.yOffset * Math.pow(0.5, diff - (n + 1));
+        logger.info(`${partialX}, ${partialY}, ${size}`);
+        size *= 0.5;
+        z = parent.z;
+        newX = parent.x;
+        newY = parent.y;
+        n++;
+    }
+    return {partialX, partialY, size};
 }
 
 export async function runServer(): Promise<void> {
@@ -73,10 +122,13 @@ export async function runServer(): Promise<void> {
                 getSource(sourceB, sw, x, y, zoom),
             ]);
 
-            const aImage = sharp(A);
-            const bImage = sharp(B);
-            // const aImageMeta = await aImage.metadata();
-            // const bImageMeta = await bImage.metadata();
+            const aImage = sharp(A[0]);
+            const aPos = getPartOfParent(zoom, A[1], x, y);
+            const bImage = sharp(B[0]);
+            const bPos = getPartOfParent(zoom, B[1], x, y);
+            logger.info(`${bPos.partialX} ${bPos.partialY} ${bPos.size}`);
+            const aImageMeta = await aImage.metadata();
+            const bImageMeta = await bImage.metadata();
 
             // const width = Math.max(aImageMeta.width ?? 0, bImageMeta.width ?? 0, 256);
             // const height = Math.max(aImageMeta.height ?? 0, bImageMeta.height ?? 0, 256);
@@ -84,8 +136,26 @@ export async function runServer(): Promise<void> {
             const height = 256;
 
             const combined = await aImage
+                .extract({
+                    left: aPos.partialX * aImageMeta.width,
+                    top: aPos.partialY * aImageMeta.height,
+                    width: aPos.size * aImageMeta.width,
+                    height: aPos.size * aImageMeta.height,
+                })
                 .resize(width, height)
-                .composite([{input: await bImage.resize(width, height).toBuffer()}])
+                .composite([
+                    {
+                        input: await bImage
+                            .extract({
+                                left: bPos.partialX * bImageMeta.width,
+                                top: bPos.partialY * bImageMeta.height,
+                                width: bPos.size * bImageMeta.width,
+                                height: bPos.size * bImageMeta.height,
+                            })
+                            .resize(width, height)
+                            .toBuffer(),
+                    },
+                ])
                 .png()
                 .toBuffer();
 

--- a/merger/src/server.ts
+++ b/merger/src/server.ts
@@ -150,7 +150,7 @@ async function getZoomOrParentTileImage(name: string, params: TileParams): Promi
     } catch (e) {
         if (zoom != '0') {
             const parentTileParams = getParentTileParams(params);
-            logger.info(
+            logger.debug(
                 `${name} - Parent tile is (${parentTileParams.zoom}, ${parentTileParams.x}, ${parentTileParams.y})`
             );
             return await getZoomOrParentTileImage(name, parentTileParams);

--- a/provider/sources/bing/bing.conf
+++ b/provider/sources/bing/bing.conf
@@ -1,4 +1,3 @@
 location /source/bing {
-    js_header_filter bing.setBingLocationHeader;
-    return 301;
+    js_content bing.setBingResponse;
 }

--- a/provider/sources/bing/bing.js
+++ b/provider/sources/bing/bing.js
@@ -23,6 +23,7 @@ const subdomainMap = {
   b: "1",
   c: "2",
 };
+const maxZoom = 20;
 
 function getBingUrl(req) {
   const uri = req.uri;
@@ -34,16 +35,31 @@ function getBingUrl(req) {
     const x = match.groups["x"];
     const y = match.groups["y"];
     const z = match.groups["z"];
+    if (parseInt(z) > maxZoom) {
+      throw new Error("Zoom level exceeded");
+    }
     return `https://ecn.t${subdomain}.tiles.virtualearth.net/tiles/a${xyzToQuadkey(
       x,
       y,
       z
     )}.jpeg?g=587&n=z`;
+  } else {
+    throw new Error("Tile URL format mismatch");
   }
 }
 
-function setBingLocationHeader(req) {
-  req.headersOut["Location"] = getBingUrl(req);
+function setBingResponse(req) {
+  try {
+    req.headersOut["Location"] = getBingUrl(req);
+    req.status = 301;
+    req.sendHeader();
+  } catch (e) {
+    req.status = 404;
+    req.headersOut["Content-Type"] = "text/plain";
+    req.sendHeader();
+    req.send(`Not found: ${e}`);
+  }
+  req.finish();
 }
 
-export default { setBingLocationHeader };
+export default { setBingResponse };


### PR DESCRIPTION
This PR fixes the limitation of the merger application not zooming past the maximum zoom of either of the tile sources.
e.g. Strava has maximum zoom of 15, but DCSNSW has down to 20. Previously 16+ would result in 404.

This works by finding the first available zoom level and extracting the sub-section of the image for the desired tile.
**Example:**
![image](https://user-images.githubusercontent.com/13784116/157250279-51e3e30b-fe24-400e-b404-6e34d2f17c50.png)

This PR also adds 404 for the Bing tile source over zoom levels of 20, and when URL regex does not match.